### PR TITLE
Compile Alembic's RenameTable the Postgres way

### DIFF
--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -12,6 +12,9 @@ try:
 except ImportError:
     pass
 else:
+    from alembic.ddl.base import RenameTable
+    compiles(RenameTable, 'redshift')(postgresql.visit_rename_table)
+
     class RedshiftImpl(postgresql.PostgresqlImpl):
         __dialect__ = 'redshift'
 

--- a/tests/test_alembic_dialect.py
+++ b/tests/test_alembic_dialect.py
@@ -1,3 +1,4 @@
+from alembic.ddl.base import RenameTable
 from alembic import migration
 
 from redshift_sqlalchemy import dialect
@@ -6,3 +7,9 @@ from redshift_sqlalchemy import dialect
 def test_configure_migration_context():
     context = migration.MigrationContext.configure(url='redshift+psycopg2://mydb')
     assert isinstance(context.impl, dialect.RedshiftImpl)
+
+
+def test_rename_table():
+    compiler = dialect.RedShiftDDLCompiler(dialect.RedshiftDialect(), None)
+    sql = compiler.process(RenameTable("old", "new", "scheme"))
+    assert sql == 'ALTER TABLE scheme."old" RENAME TO "new"'


### PR DESCRIPTION
@graingert this fixes an issue where RenameTable would be compiled as

`ALTER TABLE scheme."old" RENAME TO scheme."new"`