### PR TITLE
Use SYSDATE when func.NOW() is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,9 @@
 0.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use SYSDATE instead of NOW().
+  Thanks `bouk <https://github.com/bouk>`_.
+  (`Issue #15 <https://github.com/graingert/redshift_sqlalchemy/pull/15>`_)
 
 
 0.1.2 (2015-08-11)

--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -1,5 +1,5 @@
 from sqlalchemy import schema, util, exc
-from sqlalchemy.dialects.postgresql.base import PGDDLCompiler
+from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGCompiler
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine import reflection
 from sqlalchemy.ext.compiler import compiles
@@ -17,6 +17,12 @@ else:
 
     class RedshiftImpl(postgresql.PostgresqlImpl):
         __dialect__ = 'redshift'
+
+
+class RedshiftCompiler(PGCompiler):
+
+    def visit_now_func(self, fn, **kw):
+        return "SYSDATE"
 
 
 class RedShiftDDLCompiler(PGDDLCompiler):
@@ -127,6 +133,8 @@ class RedShiftDDLCompiler(PGDDLCompiler):
 
 class RedshiftDialect(PGDialect_psycopg2):
     name = 'redshift'
+
+    statement_compiler = RedshiftCompiler
     ddl_compiler = RedShiftDDLCompiler
 
     construct_arguments = [

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,9 @@
+from sqlalchemy import func, select
+from redshift_sqlalchemy.dialect import RedshiftDialect
+
+
+def test_func_now():
+    dialect = RedshiftDialect()
+    s = select([func.NOW().label("time")])
+    compiled = s.compile(dialect=dialect)
+    assert str(compiled) == "SELECT SYSDATE AS time"


### PR DESCRIPTION
NOW() is deprecated in Redshift http://docs.aws.amazon.com/redshift/latest/dg/r_NOW.html

@graingert 