### PR TITLE
Default to SSL with hardcoded AWS Redshift CA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 - Use SYSDATE instead of NOW().
   Thanks `bouk <https://github.com/bouk>`_.
   (`Issue #15 <https://github.com/graingert/redshift_sqlalchemy/pull/15>`_)
+- Default to SSL with hardcoded AWS Redshift CA.
+  (`Issue #20 <https://github.com/graingert/redshift_sqlalchemy/pull/20>`_)
 
 
 0.1.2 (2015-08-11)

--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -1,3 +1,4 @@
+import pkg_resources
 from sqlalchemy import schema, util, exc
 from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGCompiler
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
@@ -248,6 +249,20 @@ class RedshiftDialect(PGDialect_psycopg2):
                 column_info['type'] = NullType()
 
         return column_info
+
+    def create_connect_args(self, *args, **kwargs):
+        default_args = {
+            'sslmode': 'verify-full',
+            'sslrootcert': pkg_resources.resource_filename(
+                __name__,
+                'redshift-ssl-ca-cert.pem'
+            ),
+        }
+        cargs, cparams = super(RedshiftDialect, self).create_connect_args(
+            *args, **kwargs
+        )
+        default_args.update(cparams)
+        return cargs, default_args
 
 
 class UnloadFromSelect(Executable, ClauseElement):

--- a/tests/rs_sqla_test_utils/db.py
+++ b/tests/rs_sqla_test_utils/db.py
@@ -1,6 +1,5 @@
 import os
 
-import pkg_resources
 import sqlalchemy as sa
 from sqlalchemy.engine import url as sa_url
 
@@ -37,11 +36,5 @@ def redshift_engine_definition():
             database='dev',
             query={'client_encoding': 'utf8'},
         ),
-        connect_args={
-            'sslmode': 'verify-full',
-            'sslrootcert': pkg_resources.resource_filename(
-                'redshift_sqlalchemy',
-                'redshift-ssl-ca-cert.pem',
-            )
-        }
+        connect_args={},
     )

--- a/tests/test_default_ssl.py
+++ b/tests/test_default_ssl.py
@@ -1,0 +1,40 @@
+import sqlalchemy as sa
+
+
+CERT = b"""-----BEGIN CERTIFICATE-----
+MIIDeDCCAuGgAwIBAgIJALPHPDcjk979MA0GCSqGSIb3DQEBBQUAMIGFMQswCQYD
+VQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHU2VhdHRsZTET
+MBEGA1UEChMKQW1hem9uLmNvbTELMAkGA1UECxMCQ00xLTArBgkqhkiG9w0BCQEW
+HmNvb2tpZS1tb25zdGVyLWNvcmVAYW1hem9uLmNvbTAeFw0xMjExMDIyMzI0NDda
+Fw0xNzExMDEyMzI0NDdaMIGFMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGlu
+Z3RvbjEQMA4GA1UEBxMHU2VhdHRsZTETMBEGA1UEChMKQW1hem9uLmNvbTELMAkG
+A1UECxMCQ00xLTArBgkqhkiG9w0BCQEWHmNvb2tpZS1tb25zdGVyLWNvcmVAYW1h
+em9uLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAw949t4UZ+9n1K8vj
+PVkyehoV2kWepDmJ8YKl358nkmNwrSAGkslVttdpZS+FrgIcb44UbfVbB4bOSq0J
+qd39GYVRzSazCwr2tpibFvH87PyAX4VVUBDlCizJToEYsXkAKecs+IRqCDWG2ht/
+pibO2+T5Wp8jaxUBvDmoHY3BSgkCAwEAAaOB7TCB6jAdBgNVHQ4EFgQUE5KUaWSM
+Uml+6MZQia7DjmfjvLgwgboGA1UdIwSBsjCBr4AUE5KUaWSMUml+6MZQia7Djmfj
+vLihgYukgYgwgYUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAw
+DgYDVQQHEwdTZWF0dGxlMRMwEQYDVQQKEwpBbWF6b24uY29tMQswCQYDVQQLEwJD
+TTEtMCsGCSqGSIb3DQEJARYeY29va2llLW1vbnN0ZXItY29yZUBhbWF6b24uY29t
+ggkAs8c8NyOT3v0wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQCYZSRQ
+zJNHXyKACrqMB5j1baUGf5NA0cZ/8s5iWeC9Gkwi7cXyiq9OrBaUtJBzAJTzfWbH
+dfVaBL5FWuQsbkJWHe0mV+l4Kzl5bh/FSDSkhYR1duYRmdCXckQk6mAF6xG+1mpn
+8YlJmbEhkDmBgJ8C8p0LCMNaO2xFLlNU0O+0ng==
+-----END CERTIFICATE-----
+"""
+
+
+def test_ssl_args():
+    engine = sa.create_engine('redshift+psycopg2://test')
+    dialect = engine.dialect
+    url = engine.url
+
+    cargs, cparams = dialect.create_connect_args(url)
+
+    assert cargs == []
+    assert cparams.pop('host') == 'test'
+    assert cparams.pop('sslmode') == 'verify-full'
+    with open(cparams.pop('sslrootcert'), 'rb') as cert:
+        assert cert.read() == CERT
+    assert cparams == {}


### PR DESCRIPTION
You can still override this by setting `{'sslmode': 'disable'}`

In fact I'd recommend using `{'sslmode': 'verify-full', 'sslrootcert': '/path/to/redshift-ssl-ca-cert.pem'}`