### PR TITLE
Revert "Don't visit indexes"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,9 +2,6 @@
 0.1.3 (unreleased)
 ------------------
 
-- Don't visit indexes as Redshift doesn't support them.
-  Thanks `bouk <https://github.com/bouk>`_.
-  (`Issue #23 <https://github.com/graingert/redshift_sqlalchemy/pull/23>`_)
 - Use SYSDATE instead of NOW().
   Thanks `bouk <https://github.com/bouk>`_.
   (`Issue #15 <https://github.com/graingert/redshift_sqlalchemy/pull/15>`_)

--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -180,10 +180,6 @@ class RedShiftDDLCompiler(PGDDLCompiler):
             text += " SORTKEY"
         return text
 
-    def visit_create_index(self, element):
-        """Doesn't do anything as Redshift doesn't support indexes"""
-        return None
-
 
 class RedshiftDialect(PGDialect_psycopg2):
     name = 'redshift'

--- a/tests/test_ddl_compiler.py
+++ b/tests/test_ddl_compiler.py
@@ -3,7 +3,7 @@ import difflib
 import pytest
 from sqlalchemy import Table, Column, Integer, String, MetaData
 from sqlalchemy.exc import CompileError
-from sqlalchemy.schema import CreateTable, CreateIndex, Index
+from sqlalchemy.schema import CreateTable
 
 from redshift_sqlalchemy.dialect import RedShiftDDLCompiler, RedshiftDialect
 
@@ -221,12 +221,3 @@ class TestDDLCompiler(object):
             u"\n\tPRIMARY KEY (id)\n)\n\n"
         )
         assert expected == actual, self._compare_strings(expected, actual)
-
-    def test_visit_create_index(self, compiler):
-        t = Table("t", MetaData())
-        c = Column("a", String)
-        t.append_column(c)
-        index = Index("cool_index", c)
-        ci = CreateIndex(index)
-        compiled = compiler.process(ci)
-        assert compiled is None


### PR DESCRIPTION
This doesn't actually work, fails with `ProgrammingError: (psycopg2.ProgrammingError) can't execute an empty query`. I'll look into a better fix