### PR TITLE
Fix unicode issue with SORTKEY on python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@
 - Refactor of UnloadFromSelect including support for specifying all documented
   redshift options.
   (`Issue #27 <https://github.com/graingert/redshift_sqlalchemy/pull/27>`_)
+- Fix unicode issue with SORTKEY on python 2.
+  (`Issue #34 <https://github.com/graingert/redshift_sqlalchemy/pull/34>`_)
 
 
 0.1.2 (2015-08-11)

--- a/redshift_sqlalchemy/compat.py
+++ b/redshift_sqlalchemy/compat.py
@@ -1,0 +1,9 @@
+import sys
+
+
+py3k = sys.version_info >= (3, 0)
+
+if py3k:
+    string_types = (str,)
+else:
+    string_types = (basestring,)  # noqa

--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -12,6 +12,8 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import Executable, ClauseElement
 from sqlalchemy.types import VARCHAR, NullType
 
+from .compat import string_types
+
 
 try:
     from alembic.ddl import postgresql
@@ -254,7 +256,7 @@ class RedShiftDDLCompiler(PGDDLCompiler):
                 "mutually exclusive; you may not specify both."
             )
         if sortkey or interleaved_sortkey:
-            if isinstance(sortkey, str):
+            if isinstance(sortkey, string_types):
                 keys = [sortkey]
             else:
                 keys = sortkey or interleaved_sortkey

--- a/tests/test_ddl_compiler.py
+++ b/tests/test_ddl_compiler.py
@@ -131,6 +131,24 @@ class TestDDLCompiler(object):
         )
         assert expected == actual, self._compare_strings(expected, actual)
 
+    def test_create_table_with_unicode_sortkey(self, compiler):
+        table = Table('t1',
+                      MetaData(),
+                      Column('id', Integer, primary_key=True),
+                      Column('name', String),
+                      redshift_sortkey=u"id")
+
+        create_table = CreateTable(table)
+        actual = compiler.process(create_table)
+        expected = (
+            u"\nCREATE TABLE t1 ("
+            u"\n\tid INTEGER NOT NULL, "
+            u"\n\tname VARCHAR, "
+            u"\n\tPRIMARY KEY (id)\n) "
+            u"SORTKEY (id)\n\n"
+        )
+        assert expected == actual, self._compare_strings(expected, actual)
+
     def test_create_table_with_multiple_sortkeys(self, compiler):
 
         table = Table('t1',


### PR DESCRIPTION
This is to make sure unicode is supported in python2

@graingert 