### PR TITLE
Fix DELETE statement for Redshift Dialect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@
   (`Issue #27 <https://github.com/graingert/redshift_sqlalchemy/pull/27>`_)
 - Fix unicode issue with SORTKEY on python 2.
   (`Issue #34 <https://github.com/graingert/redshift_sqlalchemy/pull/34>`_)
-
+- Add support for Redshift ``DELETE`` statements that refer other tables in the ``WHERE``
+  clause. (`Issue #35 <https://github.com/graingert/redshift_sqlalchemy/issues/35>`_).
+  Thanks `haleemur <https://github.com/haleemur> _`.
 
 0.1.2 (2015-08-11)
 ------------------

--- a/tests/rs_sqla_test_utils/utils.py
+++ b/tests/rs_sqla_test_utils/utils.py
@@ -1,0 +1,15 @@
+__author__ = 'haleemur'
+
+import re
+from redshift_sqlalchemy import dialect
+
+
+def clean(query):
+    return re.sub(r'\s+', ' ', query).strip()
+
+
+def compile_query(q):
+    return str(q.compile(
+        dialect=dialect.RedshiftDialect(),
+        compile_kwargs={'literal_binds': True})
+    )

--- a/tests/test_delete_stmt.py
+++ b/tests/test_delete_stmt.py
@@ -1,0 +1,268 @@
+__author__ = 'Haleemur Ali'
+"""
+Tests to validate that the correct delete statement is
+issued for the redshift dialect of SQL.
+
+These tests use a simple transaction schema.
+
+For simple delete statments that don't have a ``WHERE`` clause
+or whose ``WHERE`` clause only refers to columns from the
+target table, the emitted query should match that emitted
+for the postgresql dialect.
+
+However, for more complex queries, an extra ``USING`` clause is required.
+
+For example, the following is valid in Postgresql:
+
+.. :code-block: sql
+
+    DELETE FROM customers
+    WHERE customers.id = orders.customer_id
+      AND orders.id < 100
+
+
+This same query needs to be written like this in Redshift:
+
+.. :code-block: sql
+    DELETE FROM customers
+    USING orders
+    WHERE customers.id = orders.customer_id
+      AND orders.id < 100
+
+"""
+
+from redshift_sqlalchemy.dialect import RedshiftDialect
+import sqlalchemy as sa
+
+
+meta = sa.MetaData()
+
+customers = sa.Table(
+    'customers', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+    sa.Column('first_name', sa.String(128)),
+    sa.Column('last_name', sa.String(128)),
+    sa.Column('email', sa.String(255))
+)
+
+orders = sa.Table(
+    'orders', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+    sa.Column('customer_id', sa.Integer),
+    sa.Column('total_invoiced', sa.Numeric(12, 4)),
+    sa.Column('discount_invoiced', sa.Numeric(12, 4)),
+    sa.Column('grandtotal_invoiced', sa.Numeric(12, 4)),
+    sa.Column('created_at', sa.DateTime),
+    sa.Column('updated_at', sa.DateTime)
+)
+
+items = sa.Table(
+    'items', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+    sa.Column('order_id', sa.Integer),
+    sa.Column('product_id', sa.Integer),
+    sa.Column('name', sa.String(255)),
+    sa.Column('qty', sa.Numeric(12, 4)),
+    sa.Column('price', sa.Numeric(12, 4)),
+    sa.Column('total_invoiced', sa.Numeric(12, 4)),
+    sa.Column('discount_invoiced', sa.Numeric(12, 4)),
+    sa.Column('grandtotal_invoiced', sa.Numeric(12, 4)),
+    sa.Column('created_at', sa.DateTime),
+    sa.Column('updated_at', sa.DateTime)
+)
+
+product = sa.Table(
+    'products', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False),
+    sa.Column('parent_id', sa.Integer),
+    sa.Column('name', sa.String(255)),
+    sa.Column('price', sa.Numeric(12, 4))
+)
+
+ham = sa.Table(
+    'ham', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False)
+)
+
+spam = sa.Table(
+    'spam', meta,
+    sa.Column('id', sa.Integer, primary_key=True, autoincrement=False)
+)
+
+hammy_spam = sa.Table(
+    'ham, spam', meta,
+    sa.Column('ham_id', sa.Integer, sa.ForeignKey('ham.id')),
+    sa.Column('spam_id', sa.Integer, sa.ForeignKey('spam.id'))
+)
+
+
+def get_str(stmt):
+    return str(stmt.compile(dialect=RedshiftDialect()))
+
+
+def test_delete_stmt_nowhereclause():
+    del_stmt = sa.delete(customers)
+    assert get_str(del_stmt) == 'DELETE FROM customers'
+
+
+def test_delete_stmt_simplewhereclause1():
+    del_stmt = sa.delete(customers).where(
+        customers.c.email == 'test@test.test'
+    )
+    expeted = "DELETE FROM customers " \
+              "WHERE customers.email = %(email_1)s"
+    assert get_str(del_stmt) == expeted
+
+
+def test_delete_stmt_simplewhereclause2():
+    del_stmt = sa.delete(customers).where(
+        customers.c.email.endswith('test.com')
+    )
+    expected = "DELETE FROM customers " \
+               "WHERE customers.email " \
+               "LIKE '%%' || %(email_1)s"
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_joinedwhereclause1():
+    del_stmt = sa.delete(orders).where(
+        orders.c.customer_id == customers.c.id
+    )
+    expected = "DELETE FROM orders " \
+               "USING customers " \
+               "WHERE orders.customer_id = customers.id"
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_joinedwhereclause2():
+    del_stmt = sa.delete(
+        orders
+    ).where(
+        orders.c.customer_id == customers.c.id
+    ).where(
+        orders.c.id == items.c.order_id
+    ).where(
+        customers.c.email.endswith('test.com')
+    ).where(
+        items.c.name == 'test product'
+    )
+    expected = "DELETE FROM orders " \
+               "USING customers, items " \
+               "WHERE orders.customer_id = customers.id " \
+               "AND orders.id = items.order_id " \
+               "AND (customers.email LIKE '%%' || %(email_1)s) " \
+               "AND items.name = %(name_1)s"
+
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_subqueryplusjoin():
+    del_stmt = sa.delete(
+        orders
+    ).where(
+        orders.c.customer_id.in_(
+            sa.select(
+                [customers.c.id]
+            ).where(customers.c.email.endswith('test.com'))
+        )
+    ).where(
+        orders.c.id == items.c.order_id
+    ).where(
+        items.c.name == 'test product'
+    )
+    expected = "DELETE FROM orders " \
+               "USING items " \
+               "WHERE orders.customer_id IN " \
+               "(SELECT customers.id " \
+               "\nFROM customers " \
+               "\nWHERE (customers.email LIKE '%%' || %(email_1)s)) " \
+               "AND orders.id = items.order_id " \
+               "AND items.name = %(name_1)s"
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_subquery():
+    del_stmt = sa.delete(
+        orders
+    ).where(
+        orders.c.customer_id.in_(
+            sa.select(
+                [customers.c.id]
+            ).where(customers.c.email.endswith('test.com'))
+        )
+    )
+    expected = "DELETE FROM orders " \
+               "WHERE orders.customer_id IN " \
+               "(SELECT customers.id " \
+               "\nFROM customers " \
+               "\nWHERE (customers.email LIKE '%%' || %(email_1)s))"
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_on_subquerycomma():
+    del_stmt = sa.delete(
+        ham
+    ).where(
+        ham.c.id.in_(
+            sa.select(
+                [hammy_spam.c.ham_id]
+            )
+        )
+    )
+    expected = 'DELETE FROM ham ' \
+               'WHERE ham.id IN (SELECT "ham, spam".ham_id ' \
+               '\nFROM "ham, spam")'
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_on_comma():
+    del_stmt = sa.delete(ham).where(ham.c.id == hammy_spam.c.ham_id)
+    expected = 'DELETE FROM ham USING "ham, spam" ' \
+               'WHERE ham.id = "ham, spam".ham_id'
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_on_alias():
+    parent_ = sa.alias(product)
+    del_stmt = sa.delete(
+        product
+    ).where(product.c.parent_id == parent_.c.id)
+    expected = 'DELETE FROM products ' \
+               'USING products AS products_1 ' \
+               'WHERE products.parent_id = products_1.id'
+    assert get_str(del_stmt) == expected
+
+
+def test_delete_stmt_with_comma_subquery_alias_join():
+    parent_ = sa.alias(product)
+
+    del_stmt = sa.delete(
+        items
+    ).where(
+        items.c.order_id == orders.c.id
+    ).where(
+        orders.c.customer_id.in_(
+            sa.select([customers.c.id]).where(
+                customers.c.email.endswith('test.com')
+            )
+        )
+    ).where(
+        items.c.product_id == product.c.id
+    ).where(
+        product.c.parent_id == parent_.c.id
+    ).where(
+        parent_.c.id != hammy_spam.c.ham_id
+    )
+
+    expected = "DELETE FROM items " \
+               "USING orders, products, products AS products_1, \"ham, spam\" " \
+               "WHERE items.order_id = orders.id " \
+               "AND orders.customer_id IN " \
+               "(SELECT customers.id " \
+               "\nFROM customers " \
+               "\nWHERE (customers.email LIKE '%%' || %(email_1)s)) " \
+               "AND items.product_id = products.id " \
+               "AND products.parent_id = products_1.id " \
+               "AND products_1.id != \"ham, spam\".ham_id"
+
+    assert get_str(del_stmt) == expected

--- a/tests/test_unload_from_select.py
+++ b/tests/test_unload_from_select.py
@@ -1,19 +1,9 @@
-import re
-
 import sqlalchemy as sa
 
 from redshift_sqlalchemy import dialect
 
+from rs_sqla_test_utils.utils import clean, compile_query
 
-def clean(query):
-    return re.sub(r'\s+', ' ', query).strip()
-
-
-def compile_query(q):
-    return str(q.compile(
-        dialect=dialect.RedshiftDialect(),
-        compile_kwargs={'literal_binds': True})
-    )
 
 access_key_id = 'IO1IWSZL5YRFM3BEW256'
 secret_access_key = 'A1Crw8=nJwEq+9SCgnwpYbqVSCnfB0cakn=lx4M1'


### PR DESCRIPTION
Pull request to solve Issue: [Fix DELETE statement for Redshift Dialect](https://github.com/graingert/redshift_sqlalchemy/issues/35).

Adds support so that the following sqlalchemy query

    stmt = delete(table1).where(table1.c.id==table2.c.id)

is compiled as 

    DELETE FROM table1
    USING table2
    WHERE table1.id = table2.id

instead of 

    DELETE FROM table1
    WHERE table1.id = table2.id
