### PR TITLE
Fix naming: RedShift -> Redshift

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 0.2.1 (unreleased)
 ------------------
 
-- Fixes to view support to be more in line with SQLAlchemy standards.
+- Fix view support to be more in line with SQLAlchemy standards.
   `get_view_definition` output no longer includes a trailing semicolon and
   views no longer raise an exception when reflected as `Table` objects.
   (`Issue #46 <https://github.com/graingert/redshift_sqlalchemy/pull/46>`_)
+- Rename RedShiftDDLCompiler to RedshiftDDLCompiler.
+  (`Issue #43 <https://github.com/graingert/redshift_sqlalchemy/pull/43>`_)
+
 
 0.2.0 (2015-09-04)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
-import os
-from docutils import utils as docutils_utils
-
 import sphinx.environment
 
 import redshift_sqlalchemy

--- a/docs/ddl-compiler.rst
+++ b/docs/ddl-compiler.rst
@@ -1,5 +1,5 @@
 DDL Compiler
 ============
 
-.. autoclass:: redshift_sqlalchemy.dialect.RedShiftDDLCompiler
+.. autoclass:: redshift_sqlalchemy.dialect.RedshiftDDLCompiler
    :members:

--- a/redshift_sqlalchemy/dialect.py
+++ b/redshift_sqlalchemy/dialect.py
@@ -144,7 +144,7 @@ class RedshiftCompiler(PGCompiler):
         return "SYSDATE"
 
 
-class RedShiftDDLCompiler(PGDDLCompiler):
+class RedshiftDDLCompiler(PGDDLCompiler):
     """
     Handles Redshift-specific ``CREATE TABLE`` syntax.
 
@@ -327,7 +327,7 @@ class RedshiftDialect(PGDialect_psycopg2):
     name = 'redshift'
 
     statement_compiler = RedshiftCompiler
-    ddl_compiler = RedShiftDDLCompiler
+    ddl_compiler = RedshiftDDLCompiler
 
     construct_arguments = [
         (schema.Index, {
@@ -745,7 +745,7 @@ def process_aws_credentials(access_key_id, secret_access_key,
 
 class UnloadFromSelect(Executable, ClauseElement):
     """
-    Prepares a RedShift unload statement to drop a query to Amazon S3
+    Prepares a Redshift unload statement to drop a query to Amazon S3
     https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD_command_examples.html
 
     Parameters

--- a/tests/test_alembic_dialect.py
+++ b/tests/test_alembic_dialect.py
@@ -12,6 +12,6 @@ def test_configure_migration_context():
 
 
 def test_rename_table():
-    compiler = dialect.RedShiftDDLCompiler(dialect.RedshiftDialect(), None)
+    compiler = dialect.RedshiftDDLCompiler(dialect.RedshiftDialect(), None)
     sql = compiler.process(RenameTable("old", "new", "scheme"))
     assert sql == 'ALTER TABLE scheme."old" RENAME TO "new"'

--- a/tests/test_ddl_compiler.py
+++ b/tests/test_ddl_compiler.py
@@ -5,14 +5,14 @@ from sqlalchemy import Table, Column, Integer, String, MetaData
 from sqlalchemy.exc import CompileError
 from sqlalchemy.schema import CreateTable
 
-from redshift_sqlalchemy.dialect import RedShiftDDLCompiler, RedshiftDialect
+from redshift_sqlalchemy.dialect import RedshiftDDLCompiler, RedshiftDialect
 
 
 class TestDDLCompiler(object):
 
     @pytest.fixture
     def compiler(self):
-        compiler = RedShiftDDLCompiler(RedshiftDialect(), None)
+        compiler = RedshiftDDLCompiler(RedshiftDialect(), None)
         return compiler
 
     def _compare_strings(self, expected, actual):


### PR DESCRIPTION
This is a breaking change, but IMO necessary before 1.0.